### PR TITLE
Change the itemFrequency return type

### DIFF
--- a/__tests__/textalyze.test.js
+++ b/__tests__/textalyze.test.js
@@ -78,9 +78,13 @@ describe('sanitize', () => {
 describe('itemFrequency', () => {
   test('return a new Map with frequency', () => {
     const input = ['a', 'a', 'a', 'b', 'b', 'b', 'c', 'c', 'c', 'c', 'c'];
-    const expectedOutput = new Map([['a', '0.27'], ['b', '0.27'], ['c', '0.45']]);
+    const expectedOutput = new Map([['a', 0.27], ['b', 0.27], ['c', 0.45]]);
 
-    expect(itemFrequency(input)).toEqual(expectedOutput);
+    const frequencies = itemFrequency(input);
+
+    expect(frequencies.get('a')).toBeCloseTo(expectedOutput.get('a'), 2);
+    expect(frequencies.get('b')).toBeCloseTo(expectedOutput.get('b'), 2);
+    expect(frequencies.get('c')).toBeCloseTo(expectedOutput.get('c'), 2);
   });
 
   test('handles non-array inputs', () => {

--- a/textalyze.js
+++ b/textalyze.js
@@ -18,7 +18,7 @@ const itemFrequency = (array) => {
 
   const map = itemCounts(array);
   return array.reduce((frequencies, item) => frequencies
-    .set(item, (map.get(item) / array.length).toFixed(2)), new Map());
+    .set(item, (map.get(item) / array.length)), new Map());
 };
 
 const getHistogram = (frequencies, totalChartSize) => {


### PR DESCRIPTION
Until now, the return of itemFrequency function returns map with string frequency.

Removed the toFixed function to return the float value, which eliminates the need of parsing the string frequency