### PR TITLE
Change the type exception handling of functions

### DIFF
--- a/__tests__/textalyze.test.js
+++ b/__tests__/textalyze.test.js
@@ -53,7 +53,7 @@ describe('stringToLetterArray', () => {
 
   test('handles non-string inputs', () => {
     const input = 10;
-    const expectedOutput = [];
+    const expectedOutput = ['1', '0'];
 
     expect(stringToLetterArray(input)).toEqual(expectedOutput);
   });

--- a/__tests__/textalyze.test.js
+++ b/__tests__/textalyze.test.js
@@ -89,7 +89,7 @@ describe('itemFrequency', () => {
 
   test('handles non-array inputs', () => {
     const input = 'hello';
-    const expectedOutput = new Map();
+    const expectedOutput = new Map([['hello', 1]]);
 
     expect(itemFrequency(input)).toEqual(expectedOutput);
   });

--- a/textalyze.js
+++ b/textalyze.js
@@ -10,21 +10,14 @@ const itemCounts = array => array.reduce((counts, item) => (!counts.has(item)
   ? counts.set(item, 1)
   : counts.set(item, counts.get(item) + 1)), new Map());
 
-const stringToLetterArray = (str) => {
-  if (typeof str !== 'string') {
-    return [];
-  }
-  return str.split('');
-};
+const stringToLetterArray = str => str
+  .toString()
+  .split('');
 
-const sanitize = (str) => {
-  if (typeof str !== 'string') {
-    return '';
-  }
-  return str
-    .replace(/[^a-zA-Z]/g, '')
-    .toLowerCase();
-};
+const sanitize = str => str
+  .toString()
+  .replace(/[^a-zA-Z]/g, '')
+  .toLowerCase();
 
 const itemFrequency = (array) => {
   if (typeof array !== 'object' && !array.isArray) {

--- a/textalyze.js
+++ b/textalyze.js
@@ -20,13 +20,11 @@ const sanitize = str => str
   .toLowerCase();
 
 const itemFrequency = (array) => {
-  if (typeof array !== 'object' && !array.isArray) {
-    return new Map();
-  }
+  const items = [].concat(array);
 
-  const map = itemCounts(array);
-  return array.reduce((frequencies, item) => frequencies
-    .set(item, (map.get(item) / array.length)), new Map());
+  const map = itemCounts(items);
+  return items.reduce((frequencies, item) => frequencies
+    .set(item, (map.get(item) / items.length)), new Map());
 };
 
 const getHistogram = (frequencies, totalChartSize) => {


### PR DESCRIPTION
- Removed the type check of non-string values of sanitize and stringToArray functions and added the toString() method to do the type coerce of non-string arguments
- Removed the type check of non-array arguments and added the [].concat method to do the type coercion of non-array values